### PR TITLE
kernel: Use full user defined path to ccache

### DIFF
--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -74,15 +74,9 @@ endif
 KERNEL_TOOLCHAIN_PATH_gcc := $(KERNEL_TOOLCHAIN_$(KERNEL_ARCH))/$(KERNEL_TOOLCHAIN_PREFIX_$(KERNEL_ARCH))
 
 ifneq ($(USE_CCACHE),)
-    # Detect if the system already has ccache installed to use instead of the prebuilt
-        ifneq (,$(wildcard $(OUT_DIR)/.path_interposer_origpath))
-	CCACHE_BIN := $(shell PATH=$(shell cat $(OUT_DIR)/.path_interposer_origpath):$$PATH which ccache)
-        endif
-
-    ifeq ($(CCACHE_BIN),)
-        CCACHE_BIN := $(BUILD_TOP)/prebuilts/misc/$(HOST_PREBUILT_TAG)/ccache/ccache
-        # Check that the executable is here.
-        CCACHE_BIN := $(strip $(wildcard $(CCACHE_BIN)))
+    ifneq ($(CCACHE_EXEC),)
+        # Android 10+ deprecates use of a build ccache. Only system installed ones are now allowed
+        CCACHE_BIN := $(CCACHE_EXEC)
     endif
 endif
 


### PR DESCRIPTION
The built ccache command is now deprecated and spits out errors. ccache is
also no longer used for the full build unless CCACHE_EXEC is defined. Move
the kernel to the same logic in order to actually use ccache and silence
the warnings.